### PR TITLE
Add support for queries with earth_distance

### DIFF
--- a/django_earthdistance/functions.py
+++ b/django_earthdistance/functions.py
@@ -112,3 +112,31 @@ class EarthBox(SqlFunction):
             'inside': inside_sql,
             'distance': self.distance
         }, []
+
+
+class EarthDistance(SqlFunction):
+    """
+        This function returns the great circle distance between two points on the surface of the
+        earth.
+    """
+    sql_function = 'earth_distance'
+    sql_template = '%(function)s(%(earth1)s,%(earth2)s)'
+
+    def __init__(self, earth1_function, earth2_function, *args, **kwargs):
+        self.earth1_function = earth1_function
+        self.earth2_function = earth2_function
+        self.args = args
+        self.extern_params = kwargs
+
+    def as_sql(self, qn, queryset):
+        """
+            Returns final sql expression:
+                earth_distance(ll_to_earth(column1, column2), ll_to_earth(lat, lng))
+        """
+        earth1_sql, _args = self.earth1_function.as_sql(qn, queryset)
+        earth2_sql, _args = self.earth2_function.as_sql(qn, queryset)
+        return self.sql_template % {
+            'function': self.sql_function,
+            'earth1': earth1_sql,
+            'earth2': earth2_sql
+        }, []


### PR DESCRIPTION
As suggested in issue #2, I think it would be useful to access to the more accurate `earth_distance` test rather than just the `earth_box` check. 

I think the ideal situation is to combine the two to do a cheaper `earth_box` check followed by a more accurate `earth_distance` check if the former is successful. I don't need that quite yet so I have included the lazier approach of using the `earth_distance` check directly. More details in the commit message.

I hope it seems reasonable, though I think the naming could be shuffled around a bit. Thanks for writing the app.

Michael
