### PR TITLE
Fixed an issue on Django3

### DIFF
--- a/django_earthdistance/models.py
+++ b/django_earthdistance/models.py
@@ -1,7 +1,10 @@
 # coding=utf-8
 
 from django.db import models
-import six
+try:
+    from django.utils import six
+except:
+    import six
 
 
 class LlToEarth(models.Expression):

--- a/django_earthdistance/models.py
+++ b/django_earthdistance/models.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 from django.db import models
-from django.utils import six
+import six
 
 
 class LlToEarth(models.Expression):


### PR DESCRIPTION
This extension doesn't work on Django3 because `django.utils.six` module was removed from `django-3.0`.
Please check this [release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis)